### PR TITLE
Allow falling back to process.env.EMBER_VERSION.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   build:

--- a/index.js
+++ b/index.js
@@ -27,7 +27,18 @@ function clearEdition() {
   @returns {boolean}
 */
 function _getEdition() {
-  return process.env.EMBER_EDITION;
+  let edition = process.env.EMBER_EDITION;
+
+  if (edition === undefined) {
+    // check fallback "old" location
+    edition = process.env.EMBER_VERSION;
+
+    if (edition === 'octane') {
+      console.log('Please update to using @ember/edition-utils. Using process.env.EMBER_VERSION to declare your application / addon as "octane" ready is deprecated.');
+    }
+  }
+
+  return edition;
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -2,6 +2,8 @@ const { setEdition, has, _getEdition } = require('./index');
 
 const { test } = QUnit;
 
+const OriginalConsole = Object.assign({}, console);
+
 QUnit.module('@ember/edition-utils', function(hooks) {
   // only a test helper **because** we don't want folks to
   // use this in actual shared packages, they should instead
@@ -12,6 +14,8 @@ QUnit.module('@ember/edition-utils', function(hooks) {
 
   hooks.afterEach(function() {
     delete process.env.EMBER_EDITION;
+    delete process.env.EMBER_VERSION;
+    Object.assign(console, OriginalConsole);
   });
 
   QUnit.module('setEdition', function() {
@@ -37,6 +41,19 @@ QUnit.module('@ember/edition-utils', function(hooks) {
       setEdition('classic');
 
       assert.notOk(has('octane'));
+    });
+
+    test('should infer edition from process.env.EMBER_VERSION with a warning', function(assert) {
+      assert.expect(2);
+
+      process.env.EMBER_VERSION = 'octane';
+      console.log = (...args) => {
+        assert.deepEqual(args, [
+          'Please update to using @ember/edition-utils. Using process.env.EMBER_VERSION to declare your application / addon as "octane" ready is deprecated.',
+        ]);
+      }
+
+      assert.ok(has('octane'), 'finds process.env.EMBER_VERSION');
     });
   });
 });


### PR DESCRIPTION
This ensures applications generated from earlier versions of
@ember/octane-app-blueprint will continue to work (with a warning).